### PR TITLE
fix: update OTel deps on instrumentation-document-load

### DIFF
--- a/plugins/web/opentelemetry-instrumentation-document-load/package.json
+++ b/plugins/web/opentelemetry-instrumentation-document-load/package.json
@@ -47,11 +47,11 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.1.0"
   },
   "devDependencies": {
     "@babel/core": "7.15.0",
-    "@opentelemetry/api": "1.0.2",
+    "@opentelemetry/api": "1.1.0",
     "@types/mocha": "8.2.3",
     "@types/node": "16.11.21",
     "@types/sinon": "10.0.2",
@@ -77,10 +77,10 @@
     "webpack-merge": "5.8.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "^1.0.0",
+    "@opentelemetry/core": "^1.1.0",
     "@opentelemetry/instrumentation": "^0.27.0",
-    "@opentelemetry/sdk-trace-base": "^1.0.0",
-    "@opentelemetry/sdk-trace-web": "^1.0.0",
-    "@opentelemetry/semantic-conventions": "^1.0.0"
+    "@opentelemetry/sdk-trace-base": "^1.1.0",
+    "@opentelemetry/sdk-trace-web": "^1.1.0",
+    "@opentelemetry/semantic-conventions": "^1.1.0"
   }
 }


### PR DESCRIPTION
`api@1.0.2` and `sdk-trace-web@1.0.0` are not compatible: api doesn't
	export `TracerOptions` added in `api@1.1.0`.

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

-

## Short description of the changes

-

## Checklist

- [ ] Ran `npm run test-all-versions` for the edited package(s) on the latest commit if applicable.
