### PR TITLE
chore/debug lerna

### DIFF
--- a/.github/workflows/peer-api.yaml
+++ b/.github/workflows/peer-api.yaml
@@ -16,7 +16,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install lerna
-        run: npm install -g lerna
+        run: |
+          npm install -g lerna || (
+            npx lerna info;
+            cat lerna-debug.log;
+          )
 
       - name: Install script dependencies
         run: npm install

--- a/.github/workflows/peer-api.yaml
+++ b/.github/workflows/peer-api.yaml
@@ -17,10 +17,8 @@ jobs:
 
       - name: Install lerna
         run: |
-          npm install -g lerna || (
-            npx lerna info;
-            cat lerna-debug.log;
-          )
+          npx lerna info;
+          npm install -g lerna;
 
       - name: Install script dependencies
         run: npm install


### PR DESCRIPTION
- fix: make `graphql` a peer dependency
- ci: run tests against v16
- feat: support `graphql` v16
- Remove overlapping version ranges
- feat: use latest version of `graphql` internally
- chore: add debug info with lerna
